### PR TITLE
Add persistent high score with hover details

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,10 @@
         .score {
             font-weight: bold;
         }
+        .high-score {
+            font-weight: bold;
+            margin-bottom: 20px;
+        }
         button {
             background-color: #5cb85c;
             color: white;
@@ -70,6 +74,8 @@
 </head>
 <body>
     <h1>60-Second Math Challenge</h1>
+
+    <div class="high-score" id="high-score-container">High Score: <span id="high-score">0</span></div>
     
     <div class="settings" id="settings-area">
         <h2>Game Settings</h2>
@@ -128,12 +134,19 @@
         const scoreDisplay = document.getElementById('score');
         const finalScoreDisplay = document.getElementById('final-score');
         const feedbackDisplay = document.getElementById('feedback');
-        
+        const highScoreDisplay = document.getElementById('high-score');
+        const highScoreContainer = document.getElementById('high-score-container');
+
         // Game variables
         let timeLeft = 60;
         let score = 0;
         let timer;
         let currentProblem = {};
+        let highScore = 0;
+        let highScoreDetails = {};
+        let gameSettings = {};
+
+        loadHighScore();
         
         // Event listeners
         startButton.addEventListener('click', startGame);
@@ -147,13 +160,26 @@
         // Start the game
         function startGame() {
             // Check if at least one operation is selected
-            if (!document.getElementById('addition').checked && 
-                !document.getElementById('subtraction').checked && 
-                !document.getElementById('multiplication').checked && 
+            if (!document.getElementById('addition').checked &&
+                !document.getElementById('subtraction').checked &&
+                !document.getElementById('multiplication').checked &&
                 !document.getElementById('division').checked) {
                 alert('Please select at least one operation');
                 return;
             }
+
+            const min1 = parseInt(document.getElementById('min1').value);
+            const max1 = parseInt(document.getElementById('max1').value);
+            const min2 = parseInt(document.getElementById('min2').value);
+            const max2 = parseInt(document.getElementById('max2').value);
+
+            const operations = [];
+            if (document.getElementById('addition').checked) operations.push('+');
+            if (document.getElementById('subtraction').checked) operations.push('-');
+            if (document.getElementById('multiplication').checked) operations.push('×');
+            if (document.getElementById('division').checked) operations.push('÷');
+
+            gameSettings = { min1, max1, min2, max2, operations: operations.join(', ') };
             
             // Hide settings, show game area
             settingsArea.classList.add('hidden');
@@ -266,12 +292,44 @@
             gameArea.classList.add('hidden');
             endScreen.classList.remove('hidden');
             finalScoreDisplay.textContent = score;
+
+            if (score > highScore) {
+                highScore = score;
+                highScoreDetails = gameSettings;
+                localStorage.setItem('highScore', highScore);
+                localStorage.setItem('highScoreDetails', JSON.stringify(highScoreDetails));
+                highScoreDisplay.textContent = highScore;
+                updateHighScoreTooltip();
+            }
         }
         
         // Reset the game to play again
         function resetGame() {
             endScreen.classList.add('hidden');
             settingsArea.classList.remove('hidden');
+        }
+
+        function loadHighScore() {
+            const storedScore = localStorage.getItem('highScore');
+            const storedDetails = localStorage.getItem('highScoreDetails');
+            if (storedScore) {
+                highScore = parseInt(storedScore);
+                highScoreDisplay.textContent = highScore;
+            }
+            if (storedDetails) {
+                highScoreDetails = JSON.parse(storedDetails);
+                updateHighScoreTooltip();
+            }
+        }
+
+        function updateHighScoreTooltip() {
+            if (highScoreDetails && Object.keys(highScoreDetails).length) {
+                highScoreContainer.title = `First Range: ${highScoreDetails.min1}-${highScoreDetails.max1}\n` +
+                    `Second Range: ${highScoreDetails.min2}-${highScoreDetails.max2}\n` +
+                    `Operations: ${highScoreDetails.operations}`;
+            } else {
+                highScoreContainer.title = '';
+            }
         }
         
         // Helper function to get random integer between min and max (inclusive)


### PR DESCRIPTION
## Summary
- Display a high score section with styling and tooltip support.
- Capture game settings and persist the highest score along with ranges and operations.
- Load saved high score on startup and show details on hover.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a676c63ad88326a56f7736f1003d9e