### PR TITLE
Add math-themed background and colorful sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,20 @@
             margin: 0 auto;
             padding: 20px;
             text-align: center;
+            color: #000;
+            background-color: #f0f8ff;
+            background-image: linear-gradient(to right, rgba(0,0,0,0.05) 1px, transparent 1px),
+                              linear-gradient(to bottom, rgba(0,0,0,0.05) 1px, transparent 1px);
+            background-size: 20px 20px;
+        }
+        .settings {
+            background-color: #e3f2fd;
+        }
+        .game-area {
+            background-color: #fffde7;
+        }
+        .end-screen {
+            background-color: #fde7e7;
         }
         .hidden {
             display: none;
@@ -39,6 +53,7 @@
             font-weight: bold;
         }
         .high-score {
+            background-color: #e7f4e4;
             font-weight: bold;
             margin-bottom: 20px;
         }


### PR DESCRIPTION
## Summary
- Add graph paper–style background and ensure text stays black
- Introduce colorful section backgrounds for high score, settings, game, and end screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6874193ec8326a7b5533cd6aaf17c